### PR TITLE
Do not plot ratio

### DIFF
--- a/src/strategies/market_difference.ts
+++ b/src/strategies/market_difference.ts
@@ -58,7 +58,6 @@ export class MarketDifference extends Strategy {
     this.logStatus({
       poolPrice: this.latestPoolPrice,
       exchangePrice: price,
-      priceRatio,
     });
 
     if (priceRatio > this.limit) {


### PR DESCRIPTION
The status logs are used in plots and should have the same magnitude to make sense. So we remove the ratio and only plot the prices.